### PR TITLE
Replace "not working" RiceVideoLinux.ini file with FIX94's RiceVideoLinux.ini

### DIFF
--- a/release/wii64/RiceVideoLinux.ini
+++ b/release/wii64/RiceVideoLinux.ini
@@ -1,23 +1,23 @@
 {819b9b3911ad33d5-4a}
-Name=Â´Â¸Â½Ã„Ã˜Â°Ã‘G2
+Name=´¸½ÄØ°ÑG2
 PrimaryDepthHack
 
 {0cb6456c300ee5dc-4a}
-Name=Â´Â±Â°ÃÃÂ°Ã€ÃÂ°64
+Name=´±°ÎŞ°ÀŞ°64
 AccurateTextureMapping=1
 NormalAlphaBlender=2
 NormalColorCombiner=1
 
 {f311e83524277999-4a}
-Name=Â½Â½?Ã€Â²Â¾ÃÃŠÃŸÂ½ÃÃ™Ã€ÃÃ
+Name=½½?À²¾İÊß½ŞÙÀŞÏ
 TexRectScaleHack
 
 {ff04fc84e93c25b1-4a}
-Name=Â½Ã‰ÃÃÂ·Â¯Â½Ã
+Name=½ÉÎŞ·¯½Ş
 ScreenUpdateSetting=4
 
 {8d3bda777c0d2b16-4a}
-Name=Â²ÃƒÃÃ–Â³Â½Â¹Ã‰ÃÂ°Â¼ÃÂ¬ÃÂ¼ÃÂ­Â¸
+Name=²ÃŞÖ³½¹ÉÏ°¼Ş¬İ¼Ş­¸
 AccurateTextureMapping=2
 FastTextureCRC=1
 NormalAlphaBlender=2
@@ -34,7 +34,7 @@ ForceScreenClear=1
 ScreenUpdateSetting=2
 
 {168bc185af2296df-4a}
-Name=64 ÂµÂµÂ½ÃÃ“Â³ 2
+Name=64 µµ½ŞÓ³ 2
 NormalColorCombiner=1
 
 {6910969c8d48eaf5-4a}
@@ -69,7 +69,7 @@ NormalAlphaBlender=1
 NormalColorCombiner=1
 
 {a682c18cb0cad0c2-4a}
-Name=AIÂ¼Â®Â³Â·Ã3
+Name=AI¼®³·Ş3
 NormalAlphaBlender=1
 NormalColorCombiner=1
 IncTexRectEdge
@@ -126,12 +126,12 @@ Name=Asteroids Hyper 64
 NormalAlphaBlender=1
 
 {540fcd26e0efeb53-4a}
-Name=ÃÂ®Ã›Q64 2
+Name=Á®ÛQ64 2
 NormalAlphaBlender=1
 NormalColorCombiner=1
 
 {2d56d52850aed5e4-4a}
-Name=ÃƒÃÃÃ˜Â­Â³Â²Ã—Â²Ã—ÃÃ
+Name=ÃŞİØ­³²×²×ÎŞ
 ScreenUpdateSetting=2
 
 {5db998df78098458-4a}
@@ -465,19 +465,19 @@ FrameBufferEmulation=7
 RenderToTexture=3
 
 {56a48bb9af762b5b-4a}
-Name=ÃÃÃ…ÃƒÃÃ€ÃÂºÃÂ¯ÃÃœÂ°Ã™Ã„Ã
+Name=ĞİÅÃŞÀÏºŞ¯ÁÜ°ÙÄŞ
 NormalAlphaBlender=1
 FastLoadTile
 FullTMEM=1
 AlternativeTxtSizeMethod=1
 
 {c4085c048b79fd4a-4a}
-Name=ÃŠÃÂ°ÃÂ¬Ã™ ÃŒÃŸÃ›ÃšÂ½Ã˜ÃÂ¸Ã 64
+Name=ÊŞ°Á¬Ù ÌßÛÚ½Øİ¸Ş 64
 FrameBufferEmulation=2
 ScreenUpdateSetting=3
 
 {0a98cf88b52ed58e-4a}
-Name=ÃŠÃÂ¸Â¼Â®Â³Â¼ÃÃÂ¾Â²64
+Name=ÊŞ¸¼®³¼Şİ¾²64
 NormalAlphaBlender=1
 NormalColorCombiner=1
 
@@ -525,7 +525,7 @@ NormalAlphaBlender=1
 NormalColorCombiner=1
 
 {66e8703ee8ba3844-4a}
-Name=HEIWA ÃŠÃŸÃÃÂº ÃœÂ°Ã™Ã„Ã64
+Name=HEIWA ÊßÁİº Ü°ÙÄŞ64
 RenderToTexture=3
 
 {7d1d6172d2bd1999-58}
@@ -543,7 +543,7 @@ RenderToTexture=1
 ScreenUpdateSetting=1
 
 {ac90989adf13c3f0-4a}
-Name=ÃÃ˜ÂµÃ‰ÃŒÂ«Ã„Ã‹ÃŸÂ°
+Name=ÏØµÉÌ«ÄËß°
 NormalAlphaBlender=2
 NormalColorCombiner=1
 ScreenUpdateSetting=1


### PR DESCRIPTION
This replaces the official emukidid's RiceVideoLinux.ini which causes some games (such Beetle Adventure Racing) to not apply correctly the ini settings, with the RiceVideoLinux.ini from @FIX94 (http://github.com/FIX94/Wii64), where it works correctly with the new Wii64 1.3.

Even both emukidid and FIX94 ini files for Rice are the same, have different codification, so this could cause issues. FIX94's RiceVideoLinux.ini file fix it.